### PR TITLE
Update Heroku docs for postgres SSL issue

### DIFF
--- a/docs/3.0.0-beta.x/deployment/heroku.md
+++ b/docs/3.0.0-beta.x/deployment/heroku.md
@@ -213,7 +213,7 @@ Replace the contents of `database.json` with the following:
         "database": "${process.env.DATABASE_NAME}",
         "username": "${process.env.DATABASE_USERNAME}",
         "password": "${process.env.DATABASE_PASSWORD}",
-        "ssl": true
+        "ssl": { "rejectUnauthorized": false }
       },
       "options": {}
     }


### PR DESCRIPTION
Setting ssl to true in connections.default.settings does not work with pg 8.0.0 or higher. Changing this value to { rejectUnauthorized: false } appears to fix the issue.

Fixes #5696